### PR TITLE
Add PaC config for rh02 smoke test component

### DIFF
--- a/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
@@ -1,0 +1,61 @@
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  annotations:
+    build.appstudio.openshift.io/repo: https://github.com/openshift-cnv/cnv-fbc-payloads-new?rev={{revision}}
+    build.appstudio.redhat.com/commit_sha: '{{revision}}'
+    build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
+    build.appstudio.redhat.com/target_branch: '{{target_branch}}'
+    pipelinesascode.tekton.dev/cancel-in-progress: "false"
+    pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/on-cel-expression: >-
+      event == "pull_request" && body.action == "opened" &&
+      target_branch == "main" && source_branch.startsWith("dev-rh02") &&
+      ("v4-99/lanes/dev-preview/qe/payload.yaml".pathChanged() || ".tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml".pathChanged())
+  creationTimestamp: null
+  labels:
+    appstudio.openshift.io/application: cnv-smoke-tests
+    appstudio.openshift.io/component: verify-cnv-4-99-z-build-rh02
+    pipelines.appstudio.openshift.io/type: build
+  name: verify-cnv-4-99-z-build-rh02-on-pull-request
+  namespace: vme-release-testing-tenant
+spec:
+  timeouts:
+    pipeline: "6h0m0s"
+    tasks: "5h0m0s"
+    finally: "1h0m0s"
+  params:
+  - name: git-url
+    value: '{{source_url}}'
+  - name: revision
+    value: '{{revision}}'
+  - name: output-image
+    value: quay.io/redhat-user-workloads/vme-release-testing-tenant/verify-cnv-4-99-z-build-rh02:{{revision}}
+  - name: dockerfile
+    value: Dockerfile
+  - name: path-context
+    value: v4-99/lanes/dev-preview/qe
+  - name: openshift-virtualization-test-image
+    value: quay.io/openshift-cnv/openshift-virtualization-tests:latest
+  - name: cnv-version
+    value: "4.99"
+  - name: prow-job
+    value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-dev-preview-konflux-smoke
+  - name: pull-request-number
+    value: '{{pull_request_number}}'
+  pipelineRef:
+    resolver: git
+    params:
+      - name: url
+        value: "https://github.com/openshift-cnv/tekton-tasks.git"
+      - name: revision
+        value: feat/smoke-test
+      - name: pathInRepo
+        value: "pipelines/run-cnv-smoke-tests/pipeline.yaml"
+  taskRunTemplate:
+    serviceAccountName: build-pipeline-verify-cnv-4-99-z-build-rh02
+  workspaces:
+  - name: git-auth
+    secret:
+      secretName: '{{ git_auth_secret }}'
+status: {}


### PR DESCRIPTION
## Summary

- Adds `.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml` for the `verify-cnv-4-99-z-build-rh02` component
- Targets `vme-release-testing-tenant` namespace on `kflux-prd-rh02` cluster
- CEL filter: only triggers on PRs from `dev-rh02*` source branches to `main`
- Uses the smoke test pipeline from `openshift-cnv/tekton-tasks` (feat/smoke-test branch)

## Context

Migration testing for CNV smoke tests from `stone-prd-rh01` to `kflux-prd-rh02`. This PaC file enables isolated testing on `rh02` without affecting existing `rh01` pipelines.

## Test plan

- [ ] Merge this PR
- [ ] Create a test PR from a `dev-rh02` branch touching `v4-99/lanes/dev-preview/qe/payload.yaml`
- [ ] Verify PipelineRun is created in `vme-release-testing-tenant` on `rh02`
- [ ] Verify `rh01` pipeline does NOT trigger on `dev-rh02` PRs


Made with [Cursor](https://cursor.com)