### PR TITLE
Fix rh02 PaC to target dev-rh02 branch

### DIFF
--- a/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request" && body.action == "opened" &&
-      target_branch == "main" && source_branch.startsWith("dev-rh02") &&
+      target_branch == "dev-rh02" &&
       ("v4-99/lanes/dev-preview/qe/payload.yaml".pathChanged() || ".tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml".pathChanged())
   creationTimestamp: null
   labels:


### PR DESCRIPTION
## Summary

- Changes rh02 PaC CEL filter from `target_branch == "main"` to `target_branch == "dev-rh02"`
- Prevents both clusters from triggering on the same PR

## Trigger isolation

| PR target branch | rh01 triggers? | rh02 triggers? |
|---|---|---|
| `main` | Yes | No |
| `dev-rh02` | No | Yes |

## Pre-requisite

After merging, create the `dev-rh02` branch from `main` in this repo so PRs can target it.


Made with [Cursor](https://cursor.com)