### PR TITLE
Add target-namespace annotation to rh02 PaC

### DIFF
--- a/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/target-namespace: "vme-release-testing-tenant"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request" && body.action == "opened" &&
       target_branch == "dev-rh02" &&


### PR DESCRIPTION
## Summary

Adds `pipelinesascode.tekton.dev/target-namespace: "vme-release-testing-tenant"` to the rh02 PipelineRun file.

This annotation tells PaC to only execute this PipelineRun on the cluster where `vme-release-testing-tenant` exists (rh02). The rh01 PaC controller will skip this file entirely.

## Problem

Both GitHub Apps (rh01 and rh02) are installed on this repo. Without `target-namespace`, both PaC controllers evaluate all `.tekton/` files, causing duplicate (and failing) check runs on PRs.

## Fix

`target-namespace` is the PaC-native mechanism for namespace routing across multi-cluster setups.


Made with [Cursor](https://cursor.com)