### PR TITLE
Add target-namespace to rh01 PaC files

### DIFF
--- a/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
@@ -8,6 +8,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/target-namespace: "cnv-qe-devops-tenant"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "pull_request" && body.action == "opened" &&
       (target_branch == "main" || target_branch.startsWith("dev/")) &&

--- a/.tekton/verify-cnv-4-99-z-build-push.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-push.yaml
@@ -7,6 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
+    pipelinesascode.tekton.dev/target-namespace: "cnv-qe-devops-tenant"
     pipelinesascode.tekton.dev/on-cel-expression: >-
       event == "push" &&
       (target_branch == "main" || target_branch.startsWith("dev/")) &&


### PR DESCRIPTION
## Summary

Adds `pipelinesascode.tekton.dev/target-namespace: "cnv-qe-devops-tenant"` to both rh01 PipelineRun files (pull-request and push).

## Why

With two GitHub Apps installed on this repo (rh01 and rh02), both PaC controllers evaluate all `.tekton/` files. Without `target-namespace`, rh02's PaC controller attempts to run rh01's PipelineRuns and vice versa, causing spurious failures.

## Result after merge

| PaC file | target-namespace | Runs on |
|---|---|---|
| `verify-cnv-4-99-z-build-pull-request.yaml` | `cnv-qe-devops-tenant` | rh01 only |
| `verify-cnv-4-99-z-build-push.yaml` | `cnv-qe-devops-tenant` | rh01 only |
| `verify-cnv-4-99-z-build-rh02-pull-request.yaml` | `vme-release-testing-tenant` | rh02 only |


Made with [Cursor](https://cursor.com)