### PR TITLE
feat(tekton): pass git-auth-secret param to shared smoke-test pipeline

### DIFF
--- a/.tekton/verify-cnv-4-23-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-23-z-build-rh02-pull-request.yaml
@@ -44,6 +44,8 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-odf-ocp4.23-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
+  - name: git-auth-secret
+    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
@@ -44,6 +44,8 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-dev-preview-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
+  - name: git-auth-secret
+    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
@@ -44,6 +44,8 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-dev-preview-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
+  - name: git-auth-secret
+    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/verify-cnv-5-0-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-5-0-z-build-rh02-pull-request.yaml
@@ -44,6 +44,8 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-odf-ocp5.0-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
+  - name: git-auth-secret
+    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
## Summary

- Forward PaC-generated `{{ git_auth_secret }}` as `git-auth-secret` param to the shared smoke-test pipeline
- Updated 4 pull-request PipelineRun wrappers (4-23-rh02, 4-99, 4-99-rh02, 5-0-rh02)
- Push event wrapper (`verify-cnv-4-99-z-build-push.yaml`) not modified (not in active use)

## Dependency

Requires companion PR in `tekton-tasks` to accept and use the `git-auth-secret` param.

## Test plan

- [ ] Trigger a smoke test PR on any active branch (dev-rh02-4-23, dev-rh02, dev-rh02-5-0)
- [ ] Verify PaC secret name is correctly resolved and passed to the shared pipeline
- [ ] Verify no PipelineRun validation errors on the new param


Made with [Cursor](https://cursor.com)