### PR TITLE
revert(tekton): restore 4-99 wrappers to original state

### DIFF
--- a/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-pull-request.yaml
@@ -44,8 +44,6 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-dev-preview-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
-  - name: git-auth-secret
-    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:

--- a/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-99-z-build-rh02-pull-request.yaml
@@ -44,8 +44,6 @@ spec:
     value: periodic-ci-openshift-cnv-cnv-ci-master-cnv-dev-preview-konflux-smoke
   - name: pull-request-number
     value: '{{pull_request_number}}'
-  - name: git-auth-secret
-    value: '{{git_auth_secret}}'
   pipelineRef:
     resolver: git
     params:


### PR DESCRIPTION
Revert git-auth-secret param addition from 4-99 pull-request wrappers while investigating PaC token auth for git push.