### PR TITLE
feat(tekton): point 4-23 and 5-0 wrappers to pac-token-migration branch

### DIFF
--- a/.tekton/verify-cnv-4-23-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-4-23-z-build-rh02-pull-request.yaml
@@ -52,7 +52,7 @@ spec:
       - name: url
         value: "https://github.com/openshift-cnv/tekton-tasks.git"
       - name: revision
-        value: feat/smoke-test
+        value: feat/pac-token-migration
       - name: pathInRepo
         value: "pipelines/run-cnv-smoke-tests/pipeline.yaml"
   taskRunTemplate:

--- a/.tekton/verify-cnv-5-0-z-build-rh02-pull-request.yaml
+++ b/.tekton/verify-cnv-5-0-z-build-rh02-pull-request.yaml
@@ -52,7 +52,7 @@ spec:
       - name: url
         value: "https://github.com/openshift-cnv/tekton-tasks.git"
       - name: revision
-        value: feat/smoke-test
+        value: feat/pac-token-migration
       - name: pathInRepo
         value: "pipelines/run-cnv-smoke-tests/pipeline.yaml"
   taskRunTemplate:


### PR DESCRIPTION
Update pipelineRef revision to feat/pac-token-migration for testing PaC credential-based auth on 4-23 and 5-0 smoke tests only. 4-99 remains on feat/smoke-test (unaffected).